### PR TITLE
Physijs.HeightfieldMesh

### DIFF
--- a/physi.js
+++ b/physi.js
@@ -579,10 +579,17 @@ window.Physijs = (function() {
 	// Physijs.HeightfieldMesh
 	Physijs.HeightfieldMesh = function ( geometry, material, mass, xdiv, zdiv) {
 
+		var points = [];
+		
 		Physijs.Mesh.call( this, geometry, material, mass );
 
+		for ( var i = 0; i < geometry.vertices.length; i++ ) {
+
+			points[i] = geometry.vertices[i].y;
+		}
+		
 		this._physijs.type   = 'heightfield';
-		this._physijs.points = geometry.vertices;
+		this._physijs.points = points;
 		this._physijs.xsize  = geometry.boundingBox.max.x - geometry.boundingBox.min.x;
 		this._physijs.zsize  = geometry.boundingBox.max.z - geometry.boundingBox.min.z;
 		// note - this assumes our plane geometry is square, unless we pass in specific xdiv and zdiv

--- a/physijs_worker.js
+++ b/physijs_worker.js
@@ -133,7 +133,7 @@ createShape = function( description ) {
 
 			for (var f = 0; f < description.points.length; f++) {
 				
-				Ammo.setValue(ptr + f,  description.points[f].y  , 'float');
+				Ammo.setValue(ptr + f,  description.points[f]  , 'float');
 			}
 
 			shape = new Ammo.btHeightfieldTerrainShape(


### PR DESCRIPTION
I've added the HeightfieldMesh to your library

``` javascript
Physijs.HeightfieldMesh = function ( geometry, material, mass, xdiv, zdiv) {
```

This is created by passing a THREE.PlaneGeometry, material and mass parameter.

Example:

``` javascript
this.terrainGeometry = new THREE.PlaneGeometry(this.worldWidth ,this.worldWidth , this.groundMeshSegments, this.groundMeshSegments);

// create terrain by setting y component of vertices in mesh
this.createLandscape();

// now wrap in a physics object after we've sculpted the mesh..
this.terrain = new Physijs.HeightfieldMesh(this.terrainGeometry, ground_material, 0);
```

Things to note:
- xdiv and zdiv are optional parameters, and not required if the plane is square. They should represent the number of segments in the x and z axes as this data is not explicitly carried with the THREE.PlaneGeometry object.
- only tested in a world where the y-axis is up
