### PR TITLE
Added Physijs.CapsuleMesh.

### DIFF
--- a/physi.js
+++ b/physi.js
@@ -1113,6 +1113,29 @@ window.Physijs = (function() {
 	Physijs.CylinderMesh.prototype.constructor = Physijs.CylinderMesh;
 	
 	
+	// Physijs.CapsuleMesh
+	Physijs.CapsuleMesh = function( geometry, material, mass ) {
+		var width, height, depth;
+		
+		Physijs.Mesh.call( this, geometry, material, mass );
+		
+		if ( !geometry.boundingBox ) {
+			geometry.computeBoundingBox();
+		}
+		
+		width = geometry.boundingBox.max.x - geometry.boundingBox.min.x;
+		height = geometry.boundingBox.max.y - geometry.boundingBox.min.y;
+		depth = geometry.boundingBox.max.z - geometry.boundingBox.min.z;
+		
+		this._physijs.type = 'capsule';
+		this._physijs.radius = Math.max(width / 2, depth / 2);
+		this._physijs.height = height;
+		this._physijs.mass = (typeof mass === 'undefined') ? width * height * depth : mass;
+	};
+	Physijs.CapsuleMesh.prototype = new Physijs.Mesh;
+	Physijs.CapsuleMesh.prototype.constructor = Physijs.CapsuleMesh;
+	
+	
 	// Physijs.ConeMesh
 	Physijs.ConeMesh = function( geometry, material, mass ) {
 		var width, height, depth;

--- a/physijs_worker.js
+++ b/physijs_worker.js
@@ -103,6 +103,15 @@ createShape = function( description ) {
 			}
 			break;
 		
+		case 'capsule':
+			cache_key = 'capsule_' + description.radius + '_' + description.height;
+			if ( ( shape = getShapeFromCache( cache_key ) ) === null ) {
+				// In Bullet, capsule height excludes the end spheres
+				shape = new Ammo.btCapsuleShape( description.radius, description.height - 2 * description.radius );
+				setShapeCache( cache_key, shape );
+			}
+			break;
+		
 		case 'cone':
 			cache_key = 'cone_' + description.radius + '_' + description.height;
 			if ( ( shape = getShapeFromCache( cache_key ) ) === null ) {


### PR DESCRIPTION
My use case: Using a sphere as a player character body makes it either too wide or too short in height. On the other hand, a cylinder can't climb over small obstacles due to the hard corner in the bottom. Capsule solves both problems.

PS. Congrats on your architecture - made adding this a trivial task.
