### PR TITLE
Avoid infinite loop if geometry has no vertices/triangles

### DIFF
--- a/physijs_worker.js
+++ b/physijs_worker.js
@@ -131,6 +131,8 @@ createShape = function( description ) {
 		
 		case 'concave':
 			var i, triangle, triangle_mesh = new Ammo.btTriangleMesh;
+			if (!description.triangles.length) return false
+
 			for ( i = 0; i < description.triangles.length; i++ ) {
 				triangle = description.triangles[i];
 				triangle_mesh.addTriangle(
@@ -258,7 +260,7 @@ public_functions.addObject = function( description ) {
 		localInertia, shape, motionState, rbInfo, body;
 	
 	shape = createShape( description );
-	
+	if (!shape) return
 	// If there are children then this is a compound shape
 	if ( description.children ) {
 		var compound_shape = new Ammo.btCompoundShape, _child;


### PR DESCRIPTION
If you try create a ConvexMesh of a geometry with no vertices, then ammojs gets into an infinite loop: `Uncaught RangeError: Maximum call stack size exceeded`. 

Since ammo.js is an external script to the web worker this scenario is horrible to debug as no matter what you do you can't get the stack at the time of the RangeError, so you can't see what's causing the issue. Had to copy ammojs into the worker to get proper stack trace. Anyway, this should fix you up. Due to the horror of debugging, you may want to do other similar assertions around the place to double check that no funky data ends up in ammo.
