### PR TITLE
Fixed bug that causes crashes when removing objects from the scene.

### DIFF
--- a/physi.js
+++ b/physi.js
@@ -896,7 +896,7 @@ window.Physijs = (function() {
 				this.execute( 'removeObject', { id: object._physijs.id } );
 			}
 		}
-		if ( this._materials_ref_counts.hasOwnProperty( object.material._physijs.id ) ) {
+		if ( object.material._physijs && this._materials_ref_counts.hasOwnProperty( object.material._physijs.id ) ) {
 			this._materials_ref_counts[object.material._physijs.id]--;
 			if(this._materials_ref_counts[object.material._physijs.id] == 0) {
 				this.execute( 'unRegisterMaterial', object.material._physijs );


### PR DESCRIPTION
When objects are added to a scene, _object.material._physijs_ is checked to see if it is undefined (line 852). The same is not done when objects are removed which causes "Uncaught TypeError: Cannot read property 'id' of undefined" when _object.material._physijs_ is indeed undefined. All I did was add the same check. Incidentally, this bug seems to be 2 months old.
