### PR TITLE
Ensure fidelity of "touches" arrays before dispatching collision events

### DIFF
--- a/physi.js
+++ b/physi.js
@@ -643,7 +643,7 @@ window.Physijs = (function() {
 
 		// Deal with collisions
 		for ( id1 in this._objects ) {
-			if ( !this._objects.hasOwnProperty( id1 ) ) return;
+			if ( !this._objects.hasOwnProperty( id1 ) ) continue;
 			object = this._objects[ id1 ];
 
 			// If object touches anything, ...


### PR DESCRIPTION
This fixes the non-reciprocity issue between two objects' _._physijs.touches_ arrays (see https://github.com/chandlerprall/Physijs/pull/63) as well as making sure that they are up to date **before** dispatching collision events. At the same time, the affected code has been reduced in complexity somewhat and now everything is done in a single pass (instead of additionally iterating through the "collisions" array).

The collisions array contains the objects each collider is touching as well as the objects each collidee is touching from the start, and as such, only one collision event is dispatched for every collider and collidee. Contact normals are still negated correctly thanks to the signs on normal offsets in _normal_offsets_.

Hope I didn't inadvertently screw something else up. :)
