### PR TITLE
use internal tick callback to report collisions

### DIFF
--- a/physijs_worker.js
+++ b/physijs_worker.js
@@ -20,6 +20,7 @@ var
 	getShapeFromCache,
 	setShapeCache,
 	createShape,
+	reportInternalTick,
 	reportWorld,
 	reportVehicles,
 	reportCollisions,
@@ -298,6 +299,7 @@ public_functions.init = function( params ) {
 	}
 	
 	world = new Ammo.btDiscreteDynamicsWorld( dispatcher, broadphase, solver, collisionConfiguration );
+	world.setInternalTickCallback( Runtime.addFunction( reportInternalTick ) );
 	
 	fixedTimeStep = params.fixedTimeStep;
 	rateLimit = params.rateLimit;
@@ -932,7 +934,6 @@ public_functions.simulate = function simulate( params ) {
 		world.stepSimulation( params.timeStep, params.maxSubSteps, fixedTimeStep );
 		
 		reportVehicles();
-		reportCollisions();
 		reportConstraints();
 		reportWorld();
 		
@@ -1137,6 +1138,10 @@ public_functions.dof_disableAngularMotor = function( params ) {
 	if ( constraint.getRigidBodyB() ) {
 		constraint.getRigidBodyB().activate();
 	}
+};
+
+reportInternalTick = function() {
+	reportCollisions();
 };
 
 reportWorld = function() {


### PR DESCRIPTION
Currently it's possible that not every collision event is reported if Physijs.Scene.simulate executes multiple internal simulation sub steps.

The correct way to check collisions is during a internal simulation tick callback:
http://www.bulletphysics.org/mediawiki-1.5.8/index.php?title=Collision_Callbacks_and_Triggers
http://www.bulletphysics.org/mediawiki-1.5.8/index.php/Simulation_Tick_Callbacks

I changed only collision reports to be executed during a sub step because it was obviously misbehaving. Other report types could also be changed but that's not necessarily the desired functionality.
