### PR TITLE
Renamed deprecated functions

### DIFF
--- a/physi.js
+++ b/physi.js
@@ -794,7 +794,7 @@ window.Physijs = (function() {
 				object.children[i].updateMatrix();
 				object.children[i].updateMatrixWorld();
 
-				_temp_vector3_1.getPositionFromMatrix( object.children[i].matrixWorld );
+				_temp_vector3_1.setFromMatrixPosition( object.children[i].matrixWorld );
 				_quaternion_1.setFromRotationMatrix( object.children[i].matrixWorld );
 
 				object.children[i]._physijs.position_offset = {


### PR DESCRIPTION
Keep getting: `DEPRECATED: THREE.CubeGeometry is deprecated. Use THREE.BoxGeometry instead.`

http://threejs.org/docs/#Reference/Extras.Geometries/CubeGeometry

And: `DEPRECATED: Vector3's .getPositionFromMatrix() has been renamed to .setFromMatrixPosition(). Please update your code.`
