### PR TITLE
Added onSimulationResume

### DIFF
--- a/physi.js
+++ b/physi.js
@@ -775,6 +775,10 @@ window.Physijs = (function() {
 		return constraint;
 	};
 
+	Physijs.Scene.prototype.onSimulationResume = function() {
+		this.execute( 'onSimulationResume', { } );
+	};
+
 	Physijs.Scene.prototype.removeConstraint = function( constraint ) {
 		if ( this._constraints[constraint.id ] !== undefined ) {
 			this.execute( 'removeConstraint', { id: constraint.id } );

--- a/physijs_worker.js
+++ b/physijs_worker.js
@@ -599,6 +599,10 @@ public_functions.applyForce = function ( details ) {
 	_objects[details.id].activate();
 };
 
+public_functions.onSimulationResume = function( params ) {
+	last_simulation_time = Date.now();
+};
+
 public_functions.setAngularVelocity = function ( details ) {
 
 	_vec3_1.setX(details.x);


### PR DESCRIPTION
Added onSimulationResume to allow for a simulation to be resumed
without updating all objects as if the simulation did not pause in the
first place.
