### PR TITLE
Bug: fixing collisionreport data

### DIFF
--- a/physijs_worker.js
+++ b/physijs_worker.js
@@ -1240,8 +1240,8 @@ reportCollisions = function() {
 			pt = manifold.getContactPoint( j );
 			//if ( pt.getDistance() < 0 ) {
 				offset = 2 + (collisionreport[1]++) * COLLISIONREPORT_ITEMSIZE;
-				collisionreport[ offset ] = _objects_ammo[ manifold.getBody0() ];
-				collisionreport[ offset + 1 ] = _objects_ammo[ manifold.getBody1() ];
+				collisionreport[ offset ] = _objects_ammo[ manifold.getBody0().ptr ];
+				collisionreport[ offset + 1 ] = _objects_ammo[ manifold.getBody1().ptr ];
 
 				_vector = pt.get_m_normalWorldOnB();
 				collisionreport[ offset + 2 ] = _vector.x();


### PR DESCRIPTION
`getBody0()` returns an object, therefore `_objects_ammo[ manifold.getBody0() ];` results in `undefined`, and as reportdata is Float32Array, we end up with `NaN`in report data.
Using ammo-js v0.0.2 and chrome v43.0.2357.134
